### PR TITLE
Return user details for broadcast creator

### DIFF
--- a/src/sentry/api/serializers/models/broadcast.py
+++ b/src/sentry/api/serializers/models/broadcast.py
@@ -2,6 +2,7 @@ from django.db.models import Count
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.broadcast import Broadcast, BroadcastSeen
+from sentry.users.services.user.service import user_service
 
 
 @register(Broadcast)
@@ -47,10 +48,25 @@ class AdminBroadcastSerializer(BroadcastSerializer):
 
         for item in attrs:
             attrs[item]["user_count"] = counts.get(item.id, 0)
+
+        user_ids = [b.created_by_id for b in item_list if b.created_by_id]
+        if user_ids:
+            serialized_users = {
+                u["id"]: u
+                for u in user_service.serialize_many(filter={"user_ids": user_ids}, as_user=user)
+            }
+        else:
+            serialized_users = {}
+
+        for item in item_list:
+            if item.created_by_id:
+                attrs[item]["created_by"] = serialized_users.get(str(item.created_by_id))
+
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs):
         context = super().serialize(obj, attrs, user)
         context["userCount"] = attrs["user_count"]
-        context["createdBy"] = obj.created_by_id.id if obj.created_by_id else None
+        if created_by := attrs.get("created_by"):
+            context["createdBy"] = created_by
         return context

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -50,6 +50,22 @@ class BroadcastListTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 0
 
+    def test_superuser_created_by_email(self):
+        broadcast = Broadcast.objects.create(
+            message="hello",
+            is_active=True,
+            created_by_id=self.user,
+        )
+
+        self.add_user_permission(user=self.user, permission="broadcasts.admin")
+        self.login_as(user=self.user, superuser=True)
+
+        response = self.client.get("/api/0/broadcasts/?show=all")
+        assert response.status_code == 200
+        assert any(b["id"] == str(broadcast.id) for b in response.data)
+        row = next(b for b in response.data if b["id"] == str(broadcast.id))
+        assert row["createdBy"]["email"] == self.user.email
+
     def test_basic_user_with_all(self):
         broadcast1 = Broadcast.objects.create(message="bar", is_active=True)
         Broadcast.objects.create(message="foo", is_active=False, created_by_id=self.user)


### PR DESCRIPTION
## Summary
- improve AdminBroadcastSerializer to include serialized user info
- test broadcast serialization includes the creator email for superusers

## Testing
- `python3 -m pytest tests/sentry/api/endpoints/test_broadcast_index.py::BroadcastListTest::test_superuser_created_by_email -q` *(fails: No module named pytest)*